### PR TITLE
[Extra-chapter] 通过 MiniMax API 快速入门大模型 API 调用

### DIFF
--- a/Extra-chapter/minimax-api-tutorial/code/01_basic_chat.py
+++ b/Extra-chapter/minimax-api-tutorial/code/01_basic_chat.py
@@ -1,0 +1,47 @@
+"""
+示例一：基础对话
+使用 MiniMax API（兼容 OpenAI SDK）进行单轮对话。
+"""
+
+import os
+
+from dotenv import load_dotenv
+from openai import OpenAI
+
+load_dotenv()
+
+
+def basic_chat() -> None:
+    api_key = os.environ.get("MINIMAX_API_KEY")
+    if not api_key:
+        raise ValueError("请设置环境变量 MINIMAX_API_KEY")
+
+    client = OpenAI(
+        api_key=api_key,
+        base_url="https://api.minimax.io/v1",
+    )
+
+    response = client.chat.completions.create(
+        model="MiniMax-M2.7",
+        messages=[
+            {
+                "role": "system",
+                "content": "你是一个专业的 NLP 教学助手，擅长解释自然语言处理概念。",
+            },
+            {
+                "role": "user",
+                "content": "请用简洁的语言解释 Transformer 中 Self-Attention 的核心思想。",
+            },
+        ],
+        temperature=0.7,  # MiniMax: temperature ∈ (0.0, 1.0]
+    )
+
+    print("=== MiniMax-M2.7 回复 ===")
+    print(response.choices[0].message.content)
+    print(f"\n--- Token 使用情况 ---")
+    print(f"输入 tokens: {response.usage.prompt_tokens}")
+    print(f"输出 tokens: {response.usage.completion_tokens}")
+
+
+if __name__ == "__main__":
+    basic_chat()

--- a/Extra-chapter/minimax-api-tutorial/code/02_streaming.py
+++ b/Extra-chapter/minimax-api-tutorial/code/02_streaming.py
@@ -1,0 +1,48 @@
+"""
+示例二：流式输出
+实时获取模型生成内容，提升用户体验。
+"""
+
+import os
+
+from dotenv import load_dotenv
+from openai import OpenAI
+
+load_dotenv()
+
+
+def streaming_chat() -> None:
+    api_key = os.environ.get("MINIMAX_API_KEY")
+    if not api_key:
+        raise ValueError("请设置环境变量 MINIMAX_API_KEY")
+
+    client = OpenAI(
+        api_key=api_key,
+        base_url="https://api.minimax.io/v1",
+    )
+
+    print("=== 流式输出示例（MiniMax-M2.7）===")
+    print()
+
+    stream = client.chat.completions.create(
+        model="MiniMax-M2.7",
+        messages=[
+            {
+                "role": "user",
+                "content": "请详细介绍 BERT 和 GPT 在预训练目标上的主要区别。",
+            },
+        ],
+        temperature=0.7,
+        stream=True,
+    )
+
+    for chunk in stream:
+        delta = chunk.choices[0].delta
+        if delta.content:
+            print(delta.content, end="", flush=True)
+
+    print()  # 换行
+
+
+if __name__ == "__main__":
+    streaming_chat()

--- a/Extra-chapter/minimax-api-tutorial/code/03_multi_turn.py
+++ b/Extra-chapter/minimax-api-tutorial/code/03_multi_turn.py
@@ -1,0 +1,57 @@
+"""
+示例三：多轮对话
+维护对话历史，实现上下文连贯的多轮交互。
+"""
+
+import os
+
+from dotenv import load_dotenv
+from openai import OpenAI
+
+load_dotenv()
+
+
+def multi_turn_chat() -> None:
+    api_key = os.environ.get("MINIMAX_API_KEY")
+    if not api_key:
+        raise ValueError("请设置环境变量 MINIMAX_API_KEY")
+
+    client = OpenAI(
+        api_key=api_key,
+        base_url="https://api.minimax.io/v1",
+    )
+
+    messages: list[dict] = [
+        {
+            "role": "system",
+            "content": "你是一个 NLP 学习助手，负责解答 base-llm 教程相关问题。",
+        },
+    ]
+
+    print("多轮对话示例（输入 'quit' 退出）")
+    print("-" * 40)
+
+    while True:
+        user_input = input("你: ").strip()
+        if user_input.lower() == "quit":
+            print("对话结束。")
+            break
+        if not user_input:
+            continue
+
+        messages.append({"role": "user", "content": user_input})
+
+        response = client.chat.completions.create(
+            model="MiniMax-M2.7",
+            messages=messages,
+            temperature=0.7,
+        )
+
+        assistant_reply = response.choices[0].message.content
+        messages.append({"role": "assistant", "content": assistant_reply})
+
+        print(f"助手: {assistant_reply}\n")
+
+
+if __name__ == "__main__":
+    multi_turn_chat()

--- a/Extra-chapter/minimax-api-tutorial/code/04_long_context.py
+++ b/Extra-chapter/minimax-api-tutorial/code/04_long_context.py
@@ -1,0 +1,90 @@
+"""
+示例四：长文档分析
+演示 MiniMax 204K 超长上下文窗口的处理能力。
+"""
+
+import os
+
+from dotenv import load_dotenv
+from openai import OpenAI
+
+load_dotenv()
+
+# 模拟长文档（实际使用时可替换为真实长文档内容）
+SAMPLE_DOCUMENT = """
+Attention Is All You Need (Vaswani et al., 2017)
+
+Abstract:
+The dominant sequence transduction models are based on complex recurrent or
+convolutional neural networks that include an encoder and a decoder. The best
+performing models also connect the encoder and decoder through an attention
+mechanism. We propose a new simple network architecture, the Transformer,
+based solely on attention mechanisms, dispensing with recurrence and convolutions
+entirely. Experiments on two machine translation tasks show these models to be
+superior in quality while being more parallelizable and requiring significantly
+less time to train. Our model achieves 28.4 BLEU on the WMT 2014 English-
+to-German translation task, improving over the existing best results, including
+ensembles, by over 2 BLEU. On the WMT 2014 English-to-French translation task,
+our model establishes a new single-model state-of-the-art BLEU score of 41.8 after
+training for 3.5 days on eight GPUs, a small fraction of the training costs of the
+best models from the literature.
+
+1. Introduction:
+Recurrent neural networks, long short-term memory and gated recurrent neural
+networks in particular, have been firmly established as state of the art approaches
+in sequence modeling and transduction problems such as language modeling and
+machine translation. Numerous efforts have since continued to push the boundaries
+of recurrent language models and encoder-decoder architectures.
+
+Recurrent models typically factor computation along the symbol positions of the
+input and output sequences. Aligning the positions to steps in computation time,
+they generate a sequence of hidden states ht, as a function of the previous hidden
+state ht−1 and the input for position t. This inherently sequential nature precludes
+parallelization within training examples, which becomes critical at longer sequence
+lengths, as memory constraints limit batching across examples.
+
+The Transformer architecture moves away from recurrent connections, instead relying
+entirely on an attention mechanism to draw global dependencies between input and
+output. The Transformer allows for significantly more parallelization and can reach
+a new state of the art in translation quality after being trained for as little as
+twelve hours on eight P100 GPUs.
+"""
+
+
+def analyze_long_document(document: str = SAMPLE_DOCUMENT) -> None:
+    api_key = os.environ.get("MINIMAX_API_KEY")
+    if not api_key:
+        raise ValueError("请设置环境变量 MINIMAX_API_KEY")
+
+    client = OpenAI(
+        api_key=api_key,
+        base_url="https://api.minimax.io/v1",
+    )
+
+    print("=== 长文档分析（MiniMax-M2.7，204K 超长上下文）===\n")
+
+    response = client.chat.completions.create(
+        model="MiniMax-M2.7",
+        messages=[
+            {
+                "role": "user",
+                "content": (
+                    "请对以下技术文档进行分析，输出：\n"
+                    "1. 一段不超过 100 字的摘要\n"
+                    "2. 3 个核心创新点（每点一句话）\n\n"
+                    f"文档内容：\n{document}"
+                ),
+            }
+        ],
+        temperature=0.5,
+    )
+
+    print(response.choices[0].message.content)
+    print(f"\n--- Token 使用情况 ---")
+    print(f"输入 tokens: {response.usage.prompt_tokens}")
+    print(f"输出 tokens: {response.usage.completion_tokens}")
+    print(f"（MiniMax 支持最大 204K 输入 tokens）")
+
+
+if __name__ == "__main__":
+    analyze_long_document()

--- a/Extra-chapter/minimax-api-tutorial/code/requirements.txt
+++ b/Extra-chapter/minimax-api-tutorial/code/requirements.txt
@@ -1,0 +1,2 @@
+openai>=1.0.0
+python-dotenv>=1.0.0

--- a/Extra-chapter/minimax-api-tutorial/code/test_minimax_tutorial.py
+++ b/Extra-chapter/minimax-api-tutorial/code/test_minimax_tutorial.py
@@ -1,0 +1,280 @@
+"""
+Unit tests for MiniMax API tutorial examples.
+Tests use mocked OpenAI client to avoid real API calls.
+"""
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+CODE_DIR = Path(__file__).parent.parent / "code"
+sys.path.insert(0, str(CODE_DIR))
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _make_mock_response(content: str = "Mock response text"):
+    message = MagicMock()
+    message.content = content
+    choice = MagicMock()
+    choice.message = message
+    usage = MagicMock()
+    usage.prompt_tokens = 50
+    usage.completion_tokens = 100
+    response = MagicMock()
+    response.choices = [choice]
+    response.usage = usage
+    return response
+
+
+def _make_mock_stream_chunk(content: str):
+    delta = MagicMock()
+    delta.content = content
+    choice = MagicMock()
+    choice.delta = delta
+    chunk = MagicMock()
+    chunk.choices = [choice]
+    return chunk
+
+
+# ---------------------------------------------------------------------------
+# Tests for 01_basic_chat.py
+# ---------------------------------------------------------------------------
+class TestBasicChat(unittest.TestCase):
+    @patch.dict("os.environ", {"MINIMAX_API_KEY": "test-key-123"})
+    @patch("openai.OpenAI")
+    def test_basic_chat_success(self, mock_openai_cls):
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_client.chat.completions.create.return_value = _make_mock_response(
+            "Self-Attention 的核心思想是让序列中每个位置都能关注到其他所有位置。"
+        )
+
+        mod = _load_module("basic_chat", CODE_DIR / "01_basic_chat.py")
+        mod.basic_chat()
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        self.assertEqual(call_kwargs["model"], "MiniMax-M2.7")
+        self.assertAlmostEqual(call_kwargs["temperature"], 0.7)
+        # temperature must be in (0.0, 1.0]
+        self.assertGreater(call_kwargs["temperature"], 0.0)
+        self.assertLessEqual(call_kwargs["temperature"], 1.0)
+
+    @patch.dict("os.environ", {"MINIMAX_API_KEY": "test-key-123"})
+    @patch("openai.OpenAI")
+    def test_system_prompt_included(self, mock_openai_cls):
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_client.chat.completions.create.return_value = _make_mock_response()
+
+        mod = _load_module("basic_chat", CODE_DIR / "01_basic_chat.py")
+        mod.basic_chat()
+
+        messages = mock_client.chat.completions.create.call_args[1]["messages"]
+        roles = [m["role"] for m in messages]
+        self.assertIn("system", roles)
+        self.assertIn("user", roles)
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_missing_api_key_raises(self):
+        mod = _load_module("basic_chat2", CODE_DIR / "01_basic_chat.py")
+        with self.assertRaises(ValueError, msg="应在缺少 API Key 时抛出 ValueError"):
+            mod.basic_chat()
+
+    @patch.dict("os.environ", {"MINIMAX_API_KEY": "test-key-123"})
+    @patch("openai.OpenAI")
+    def test_base_url_is_minimax(self, mock_openai_cls):
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_client.chat.completions.create.return_value = _make_mock_response()
+
+        mod = _load_module("basic_chat3", CODE_DIR / "01_basic_chat.py")
+        mod.basic_chat()
+
+        init_kwargs = mock_openai_cls.call_args[1]
+        self.assertIn("minimax.io", init_kwargs.get("base_url", ""))
+
+
+# ---------------------------------------------------------------------------
+# Tests for 02_streaming.py
+# ---------------------------------------------------------------------------
+class TestStreaming(unittest.TestCase):
+    @patch.dict("os.environ", {"MINIMAX_API_KEY": "test-key-123"})
+    @patch("openai.OpenAI")
+    def test_streaming_output(self, mock_openai_cls):
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+
+        chunks = [
+            _make_mock_stream_chunk("BERT"),
+            _make_mock_stream_chunk(" 使用 MLM"),
+            _make_mock_stream_chunk("，GPT 使用 CLM"),
+        ]
+        mock_client.chat.completions.create.return_value = iter(chunks)
+
+        mod = _load_module("streaming", CODE_DIR / "02_streaming.py")
+        mod.streaming_chat()
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        self.assertTrue(call_kwargs.get("stream"), "stream 参数应为 True")
+
+    @patch.dict("os.environ", {"MINIMAX_API_KEY": "test-key-123"})
+    @patch("openai.OpenAI")
+    def test_streaming_uses_minimax_model(self, mock_openai_cls):
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_client.chat.completions.create.return_value = iter([])
+
+        mod = _load_module("streaming2", CODE_DIR / "02_streaming.py")
+        mod.streaming_chat()
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        self.assertIn("MiniMax", call_kwargs["model"])
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_streaming_missing_key_raises(self):
+        mod = _load_module("streaming3", CODE_DIR / "02_streaming.py")
+        with self.assertRaises(ValueError):
+            mod.streaming_chat()
+
+
+# ---------------------------------------------------------------------------
+# Tests for 03_multi_turn.py
+# ---------------------------------------------------------------------------
+class TestMultiTurn(unittest.TestCase):
+    @patch.dict("os.environ", {"MINIMAX_API_KEY": "test-key-123"})
+    @patch("openai.OpenAI")
+    @patch("builtins.input", side_effect=["你好", "quit"])
+    def test_multi_turn_adds_history(self, mock_input, mock_openai_cls):
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_client.chat.completions.create.return_value = _make_mock_response("你好！有什么可以帮助你的？")
+
+        mod = _load_module("multi_turn", CODE_DIR / "03_multi_turn.py")
+        mod.multi_turn_chat()
+
+        # Should have been called once for the "你好" message
+        self.assertEqual(mock_client.chat.completions.create.call_count, 1)
+        messages = mock_client.chat.completions.create.call_args[1]["messages"]
+        user_messages = [m for m in messages if m["role"] == "user"]
+        self.assertEqual(len(user_messages), 1)
+        self.assertEqual(user_messages[0]["content"], "你好")
+
+    @patch.dict("os.environ", {"MINIMAX_API_KEY": "test-key-123"})
+    @patch("openai.OpenAI")
+    @patch("builtins.input", side_effect=["quit"])
+    def test_multi_turn_quit_immediately(self, mock_input, mock_openai_cls):
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+
+        mod = _load_module("multi_turn2", CODE_DIR / "03_multi_turn.py")
+        mod.multi_turn_chat()
+
+        mock_client.chat.completions.create.assert_not_called()
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_multi_turn_missing_key_raises(self):
+        mod = _load_module("multi_turn3", CODE_DIR / "03_multi_turn.py")
+        with self.assertRaises(ValueError):
+            mod.multi_turn_chat()
+
+
+# ---------------------------------------------------------------------------
+# Tests for 04_long_context.py
+# ---------------------------------------------------------------------------
+class TestLongContext(unittest.TestCase):
+    @patch.dict("os.environ", {"MINIMAX_API_KEY": "test-key-123"})
+    @patch("openai.OpenAI")
+    def test_long_context_analysis(self, mock_openai_cls):
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_client.chat.completions.create.return_value = _make_mock_response(
+            "摘要：Transformer 是一种完全基于注意力机制的序列模型。\n"
+            "创新点：1. 抛弃循环结构 2. 多头注意力 3. 可并行训练"
+        )
+
+        mod = _load_module("long_ctx", CODE_DIR / "04_long_context.py")
+        mod.analyze_long_document("这是一段测试文档内容。")
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        self.assertEqual(call_kwargs["model"], "MiniMax-M2.7")
+        self.assertGreater(call_kwargs["temperature"], 0.0)
+
+    @patch.dict("os.environ", {"MINIMAX_API_KEY": "test-key-123"})
+    @patch("openai.OpenAI")
+    def test_document_included_in_message(self, mock_openai_cls):
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_client.chat.completions.create.return_value = _make_mock_response()
+
+        test_doc = "这是专属测试文档 XYZ123"
+        mod = _load_module("long_ctx2", CODE_DIR / "04_long_context.py")
+        mod.analyze_long_document(test_doc)
+
+        messages = mock_client.chat.completions.create.call_args[1]["messages"]
+        combined_content = " ".join(m.get("content", "") for m in messages)
+        self.assertIn("XYZ123", combined_content)
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_long_context_missing_key_raises(self):
+        mod = _load_module("long_ctx3", CODE_DIR / "04_long_context.py")
+        with self.assertRaises(ValueError):
+            mod.analyze_long_document("test")
+
+
+# ---------------------------------------------------------------------------
+# Tests for temperature constraint (MiniMax-specific)
+# ---------------------------------------------------------------------------
+class TestTemperatureConstraint(unittest.TestCase):
+    """Verify all examples use temperature in (0.0, 1.0]"""
+
+    def _get_temperature(self, module_path: Path, mock_fn: str, extra_patches=None):
+        with patch.dict("os.environ", {"MINIMAX_API_KEY": "test-key"}):
+            with patch("openai.OpenAI") as mock_openai_cls:
+                mock_client = MagicMock()
+                mock_openai_cls.return_value = mock_client
+                mock_client.chat.completions.create.return_value = _make_mock_response()
+                mock_client.chat.completions.create.return_value = iter([]) if "stream" in str(module_path) else _make_mock_response()
+
+                mod = _load_module(f"temp_{module_path.stem}", module_path)
+                try:
+                    patches = extra_patches or []
+                    func = getattr(mod, mock_fn)
+                    for p in patches:
+                        p.start()
+                    try:
+                        func()
+                    except Exception:
+                        pass
+                    finally:
+                        for p in patches:
+                            p.stop()
+                except Exception:
+                    pass
+
+                if mock_client.chat.completions.create.called:
+                    return mock_client.chat.completions.create.call_args[1].get("temperature")
+        return None
+
+    def test_all_temps_in_valid_range(self):
+        files_and_funcs = [
+            (CODE_DIR / "01_basic_chat.py", "basic_chat"),
+            (CODE_DIR / "02_streaming.py", "streaming_chat"),
+            (CODE_DIR / "04_long_context.py", "analyze_long_document"),
+        ]
+        for path, fn_name in files_and_funcs:
+            temp = self._get_temperature(path, fn_name)
+            if temp is not None:
+                self.assertGreater(temp, 0.0, f"{path.name}: temperature 必须 > 0.0")
+                self.assertLessEqual(temp, 1.0, f"{path.name}: temperature 必须 <= 1.0")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/Extra-chapter/minimax-api-tutorial/readme.md
+++ b/Extra-chapter/minimax-api-tutorial/readme.md
@@ -1,0 +1,295 @@
+# 通过 MiniMax API 快速入门大模型 API 调用
+
+> **阅读建议**：适合在读完第 5 章（预训练模型）或第 6 章（深入大模型架构）之后阅读。本专题介绍如何通过商业云端 API 调用大模型，作为本地模型部署的补充视角。
+
+## 背景与动机
+
+在本教程主线中，我们学习了如何从零理解、训练和部署大模型。然而在工程实践中，直接调用商业大模型 API 是更常见的选择——它无需本地 GPU 资源，开箱即用，且具备极大的上下文窗口，非常适合快速验证想法、构建应用原型。
+
+**MiniMax** 是国内领先的大模型提供商，其 **MiniMax-M2.7** 系列模型具备 **204K tokens 超长上下文**，并提供兼容 OpenAI 接口规范的 API，方便开发者无缝切换。
+
+本专题将带你：
+1. 了解 MiniMax API 的核心特性
+2. 完成环境配置与第一次 API 调用
+3. 实践多轮对话、流式输出等常用功能
+4. 理解 API 调用与本地推理的异同
+
+---
+
+## MiniMax 模型简介
+
+| 模型 | 上下文窗口 | 适用场景 |
+|------|-----------|----------|
+| `MiniMax-M2.7` | 204K tokens | 高精度任务、长文档分析 |
+| `MiniMax-M2.7-highspeed` | 204K tokens | 对响应速度有要求的场景 |
+| `MiniMax-M2.5` | 204K tokens | 均衡性能与成本 |
+| `MiniMax-M2.5-highspeed` | 204K tokens | 高并发、低延迟应用 |
+
+> **注意**：MiniMax 所有模型的 `temperature` 参数范围为 **(0.0, 1.0]**（不包含 0，包含 1），与部分其他提供商不同，请注意调整。
+
+---
+
+## 环境准备
+
+### 1. 获取 API Key
+
+前往 [MiniMax 开放平台](https://www.minimax.io) 注册并创建 API Key。
+
+### 2. 安装依赖
+
+MiniMax 的 API 完全兼容 OpenAI SDK，无需安装额外客户端：
+
+```bash
+pip install openai python-dotenv
+```
+
+### 3. 配置环境变量
+
+创建 `.env` 文件（不要将其提交到 Git）：
+
+```bash
+MINIMAX_API_KEY=your_api_key_here
+```
+
+---
+
+## 快速开始
+
+### 示例一：基础对话
+
+```python
+# code/01_basic_chat.py
+from openai import OpenAI
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+client = OpenAI(
+    api_key=os.environ.get("MINIMAX_API_KEY"),
+    base_url="https://api.minimax.io/v1",
+)
+
+response = client.chat.completions.create(
+    model="MiniMax-M2.7",
+    messages=[
+        {
+            "role": "system",
+            "content": "你是一个专业的 NLP 教学助手，擅长解释自然语言处理概念。",
+        },
+        {
+            "role": "user",
+            "content": "请用简洁的语言解释 Transformer 中 Self-Attention 的核心思想。",
+        },
+    ],
+    temperature=0.7,  # MiniMax: temperature ∈ (0.0, 1.0]
+)
+
+print(response.choices[0].message.content)
+```
+
+运行：
+
+```bash
+python code/01_basic_chat.py
+```
+
+---
+
+### 示例二：流式输出
+
+对于长文本生成，流式输出（Streaming）能显著提升用户体验——模型生成内容时实时返回，而非等待全部完成：
+
+```python
+# code/02_streaming.py
+from openai import OpenAI
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+client = OpenAI(
+    api_key=os.environ.get("MINIMAX_API_KEY"),
+    base_url="https://api.minimax.io/v1",
+)
+
+stream = client.chat.completions.create(
+    model="MiniMax-M2.7",
+    messages=[
+        {"role": "user", "content": "请详细介绍 BERT 和 GPT 在预训练目标上的主要区别。"},
+    ],
+    temperature=0.7,
+    stream=True,
+)
+
+for chunk in stream:
+    if chunk.choices[0].delta.content:
+        print(chunk.choices[0].delta.content, end="", flush=True)
+print()  # 换行
+```
+
+---
+
+### 示例三：多轮对话
+
+```python
+# code/03_multi_turn.py
+from openai import OpenAI
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+client = OpenAI(
+    api_key=os.environ.get("MINIMAX_API_KEY"),
+    base_url="https://api.minimax.io/v1",
+)
+
+messages = [
+    {"role": "system", "content": "你是一个 NLP 学习助手，负责解答 base-llm 教程相关问题。"},
+]
+
+print("多轮对话示例（输入 'quit' 退出）")
+print("-" * 40)
+
+while True:
+    user_input = input("你: ").strip()
+    if user_input.lower() == "quit":
+        break
+    if not user_input:
+        continue
+
+    messages.append({"role": "user", "content": user_input})
+
+    response = client.chat.completions.create(
+        model="MiniMax-M2.7",
+        messages=messages,
+        temperature=0.7,
+    )
+
+    assistant_reply = response.choices[0].message.content
+    messages.append({"role": "assistant", "content": assistant_reply})
+
+    print(f"助手: {assistant_reply}\n")
+```
+
+---
+
+### 示例四：长文档分析（利用 204K 超长上下文）
+
+MiniMax 204K 的超长上下文在处理长文档时具有明显优势。以下示例展示如何将长文本一次性送入模型进行分析：
+
+```python
+# code/04_long_context.py
+from openai import OpenAI
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+client = OpenAI(
+    api_key=os.environ.get("MINIMAX_API_KEY"),
+    base_url="https://api.minimax.io/v1",
+)
+
+# 模拟一段较长的技术文档
+long_document = """
+[Transformer 论文摘要（模拟长文档）]
+
+Attention Is All You Need
+
+Abstract:
+The dominant sequence transduction models are based on complex recurrent or
+convolutional neural networks that include an encoder and a decoder. The best
+performing models also connect the encoder and decoder through an attention
+mechanism. We propose a new simple network architecture, the Transformer,
+based solely on attention mechanisms, dispensing with recurrence and convolutions
+entirely. Experiments on two machine translation tasks show these models to be
+superior in quality while being more parallelizable and requiring significantly
+less time to train.
+
+... [此处可放入实际的长文档内容，MiniMax 支持最长 204K tokens] ...
+"""
+
+response = client.chat.completions.create(
+    model="MiniMax-M2.7",
+    messages=[
+        {
+            "role": "user",
+            "content": f"请对以下技术文档进行摘要，并提炼出 3 个核心创新点：\n\n{long_document}",
+        }
+    ],
+    temperature=0.5,
+)
+
+print(response.choices[0].message.content)
+print(f"\n--- Token 使用情况 ---")
+print(f"输入 tokens: {response.usage.prompt_tokens}")
+print(f"输出 tokens: {response.usage.completion_tokens}")
+```
+
+---
+
+## API 调用 vs 本地推理：核心差异
+
+| 维度 | API 调用（MiniMax） | 本地推理（HuggingFace） |
+|------|-------------------|------------------------|
+| **硬件要求** | 无需 GPU | 需要高显存 GPU |
+| **上下文长度** | 204K tokens | 受限于 GPU 显存 |
+| **延迟** | 依赖网络 | 本地推理延迟低 |
+| **成本** | 按 token 计费 | 一次性硬件投入 |
+| **数据隐私** | 数据发送至云端 | 数据完全本地 |
+| **模型控制** | 固定模型版本 | 可自定义微调 |
+
+> **选型建议**：原型开发、快速验证 → 优先 API；生产部署、数据敏感 → 考虑本地部署。
+
+---
+
+## 与 OpenAI 的兼容性
+
+MiniMax 的 API 端点完全兼容 OpenAI SDK，只需修改两处：
+
+```python
+# OpenAI 配置
+client = OpenAI(
+    api_key="sk-...",
+    # base_url 默认为 https://api.openai.com/v1
+)
+
+# 切换到 MiniMax（仅需修改这两处）
+client = OpenAI(
+    api_key=os.environ.get("MINIMAX_API_KEY"),
+    base_url="https://api.minimax.io/v1",  # ← 修改 base_url
+)
+# model 参数改为 "MiniMax-M2.7" 等 MiniMax 模型名
+```
+
+这意味着已有的基于 OpenAI SDK 的代码，可以以最小改动切换到 MiniMax。
+
+---
+
+## 实践练习
+
+1. **基础练习**：修改 `01_basic_chat.py`，尝试不同的 `temperature` 值（如 0.1、0.5、1.0），观察输出的差异。
+
+2. **进阶练习**：使用 `MiniMax-M2.7` 和 `MiniMax-M2.7-highspeed` 分别请求同一问题，对比响应时间与质量。
+
+3. **综合实践**：选取一篇英文论文的 Abstract，让模型翻译并总结，体验长上下文能力。
+
+---
+
+## 经验总结
+
+- **temperature 范围**：MiniMax 的 temperature 参数区间为 (0.0, 1.0]，设置为 0 会报错，建议最小值设为 0.01。
+- **模型选择**：日常开发调试优先用 `MiniMax-M2.7-highspeed`，对精度要求高时换 `MiniMax-M2.7`。
+- **长文档处理**：204K 超长上下文可以一次性处理大量文本，避免繁琐的文本切分。
+- **成本控制**：开发阶段可设置较短的 `max_tokens` 限制输出长度，节省 API 费用。
+
+---
+
+## 参考资料
+
+- [MiniMax 开放平台文档](https://www.minimax.io/docs)
+- [OpenAI Python SDK](https://github.com/openai/openai-python)
+- [Attention Is All You Need (Vaswani et al., 2017)](https://arxiv.org/abs/1706.03762)
+- Base LLM 主教程：[第 5 章 - 预训练模型](../../docs/chapter5/14_GPT.md)、[第 6 章 - 深入大模型架构](../../docs/chapter6/17_handcraft_llama2.md)


### PR DESCRIPTION
## [Extra-chapter] 通过 MiniMax API 快速入门大模型 API 调用

### 专题简介

本专题为 `Extra-chapter` 新增了一篇面向学习者的实践教程，介绍如何通过 **MiniMax API** 调用云端大模型，作为主教程"本地模型训练与部署"的互补视角。

适合在读完第 5 章（预训练模型）或第 6 章（深入大模型架构）之后阅读。

### 新增内容

**`Extra-chapter/minimax-api-tutorial/`**

| 文件 | 说明 |
|------|------|
| `readme.md` | 专题主文档，含模型介绍、环境配置、4 个渐进式示例、API 与本地推理对比表 |
| `code/01_basic_chat.py` | 基础单轮对话 |
| `code/02_streaming.py` | 流式输出 |
| `code/03_multi_turn.py` | 多轮对话（维护历史） |
| `code/04_long_context.py` | 长文档分析（演示 204K 上下文） |
| `code/requirements.txt` | 依赖：`openai>=1.0.0`, `python-dotenv>=1.0.0` |
| `code/test_minimax_tutorial.py` | 14 个单元测试（全部通过，无需真实 API Key） |

### 核心教学内容

- **MiniMax M2.7 / M2.7-highspeed / M2.5 / M2.5-highspeed**，均支持 204K tokens 超长上下文
- 兼容 OpenAI SDK，只需修改 `base_url` 即可从 OpenAI 切换到 MiniMax
- temperature 参数范围 (0.0, 1.0] 的注意事项
- API 调用 vs 本地推理的核心差异对比

### 测试说明

```bash
cd Extra-chapter/minimax-api-tutorial/code
pip install -r requirements.txt
python -m pytest test_minimax_tutorial.py -v
# 14 passed in 1.60s
```

集成测试（需要真实 API Key）：

```bash
export MINIMAX_API_KEY=your_key_here
python 01_basic_chat.py
```

### 与主教程的关系

- 补充第 5/6 章：理解了本地模型原理后，了解云端 API 调用方式
- 补充第 14 章：与 FastAPI 部署方案形成对比，帮助读者选型
